### PR TITLE
Add check for raven when checking detectors

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -208,6 +208,7 @@ bool Util::IsDetectorType(const sc2::UnitTypeID & type)
         case sc2::UNIT_TYPEID::TERRAN_MISSILETURRET    : return true;
         case sc2::UNIT_TYPEID::ZERG_SPORECRAWLER       : return true;
         case sc2::UNIT_TYPEID::PROTOSS_PHOTONCANNON    : return true;
+        case sc2::UNIT_TYPEID::TERRAN_RAVEN            : return true;
         default: return false;
     }
 }


### PR DESCRIPTION
As mentioned by in https://github.com/davechurchill/commandcenter/pull/37 a check for raven is missing.

The full list of detectors is here:
http://wiki.teamliquid.net/starcraft2/Detector

The units that need one of their abilities to be active for detection are still left out.