### PR TITLE
 Do not try to build Protoss building without Pylon.

### DIFF
--- a/src/BuildingManager.cpp
+++ b/src/BuildingManager.cpp
@@ -408,10 +408,6 @@ std::vector<UnitType> BuildingManager::buildingsQueued() const
 
 CCTilePosition BuildingManager::getBuildingLocation(const Building & b)
 {
-    size_t numPylons = m_bot.UnitInfo().getUnitTypeCount(Players::Self, Util::GetSupplyProvider(m_bot.GetPlayerRace(Players::Self), m_bot), true);
-
-    // TODO: if requires psi and we have no pylons return 0
-
     if (b.type.isRefinery())
     {
         return m_buildingPlacer.getRefineryPosition();
@@ -421,6 +417,17 @@ CCTilePosition BuildingManager::getBuildingLocation(const Building & b)
     {
         return m_bot.Bases().getNextExpansion(Players::Self);
     }
+
+	//In case of Protoss if there are no finished Plons only a Pylon can be build.
+	if (m_bot.GetPlayerRace(Players::Self) == CCRace::Protoss)
+	{
+		size_t numPylons = m_bot.UnitInfo().getUnitTypeCount(Players::Self, Util::GetSupplyProvider(m_bot.GetPlayerRace(Players::Self), m_bot), true);
+		if (numPylons == 0 && !b.type.isSupplyProvider())
+		{
+			return CCTilePosition(0, 0);
+		}
+	}
+	
 
     // get a position within our region
     // TODO: put back in special pylon / cannon spacing

--- a/src/BuildingManager.cpp
+++ b/src/BuildingManager.cpp
@@ -418,7 +418,7 @@ CCTilePosition BuildingManager::getBuildingLocation(const Building & b)
         return m_bot.Bases().getNextExpansion(Players::Self);
     }
 
-	//In case of Protoss if there are no finished Plons only a Pylon can be build.
+	//In case of Protoss if there are no finished Pylons only a Pylon can be build.
 	if (m_bot.GetPlayerRace(Players::Self) == CCRace::Protoss)
 	{
 		size_t numPylons = m_bot.UnitInfo().getUnitTypeCount(Players::Self, Util::GetSupplyProvider(m_bot.GetPlayerRace(Players::Self), m_bot), true);

--- a/src/UnitType.cpp
+++ b/src/UnitType.cpp
@@ -112,7 +112,7 @@ bool UnitType::isCombatUnit() const
 
 bool UnitType::isSupplyProvider() const
 {
-    return (supplyProvided() < 0) && !isResourceDepot();
+    return (supplyProvided() > 0) && !isResourceDepot();
 }
 
 bool UnitType::isResourceDepot() const


### PR DESCRIPTION
Hi,

you can not build Protoss buildings if there is no completed Pylon. Assuming a Gateway is next in line and the first Pylon is not yet finsihed, the current commandcenter bot still tries which means it queries all possible building positions each game loop. This slows down the game A LOT until the Pylon is finished. This pull request should fix it.

Regards